### PR TITLE
Two sync fixes/improvements

### DIFF
--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -86,12 +86,12 @@ module.exports = function *(argv) {
   }
 
   // Verify source database
-  let r = require('rethinkdbdash')({host: sourceHost, port: sourcePort, user: sourceUser, password: sourcePassword})
-  // get dbList
-  let dbList = yield r.dbList().run()
+  let sr = require('rethinkdbdash')({host: sourceHost, port: sourcePort, user: sourceUser, password: sourcePassword})
+  // get sourceDBList
+  let sourceDBList = yield sr.dbList().run()
   // get sourceTableList
-  let sourceTableList = yield r.db(sourceDB).tableList().run()
-  if (!dbList.includes(sourceDB)) {
+  let sourceTableList = yield sr.db(sourceDB).tableList().run()
+  if (!sourceDBList.includes(sourceDB)) {
     console.log('Source DB does not exist!')
     return
   }
@@ -144,10 +144,10 @@ module.exports = function *(argv) {
     tablesToSync = sourceTableList
   }
 
-  let sr = require('rethinkdbdash')({host: sourceHost, port: sourcePort, user: sourceUser, password: sourcePassword})
   let tr = require('rethinkdbdash')({host: targetHost, port: targetPort, user: targetUser, password: targetPassword})
 
-  if (!dbList.includes(targetDB)) {
+  let targetDBList = yield tr.dbList().run()
+  if (!targetDBList.includes(targetDB)) {
     console.log('Target DB does not exist, creating...')
     yield tr.dbCreate(targetDB).run()
   }
@@ -193,11 +193,11 @@ module.exports = function *(argv) {
     let queue = blockingQueue()
 
     console.log(`Synchronizing ${totalRecords} records in ${table}...                                                                  `)
-    let sourceCursor = yield sr.db(sourceDB).table(table).orderBy({index: r.asc('id')})
-      .map(function (row) { return {id: row('id'), hash: r.uuid(row.toJSON())} })
+    let sourceCursor = yield sr.db(sourceDB).table(table).orderBy({index: sr.asc('id')})
+      .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
       .run({cursor: true})
-    let targetCursor = yield tr.db(targetDB).table(table).orderBy({index: r.asc('id')})
-      .map(function (row) { return {id: row('id'), hash: r.uuid(row.toJSON())} })
+    let targetCursor = yield tr.db(targetDB).table(table).orderBy({index: tr.asc('id')})
+      .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
       .run({cursor: true})
 
     let si = {}
@@ -254,7 +254,7 @@ module.exports = function *(argv) {
       }
     }
 
-    yield r.db(targetDB).table(table).sync().run()
+    yield tr.db(targetDB).table(table).sync().run()
 
     tableDone = true
   }


### PR DESCRIPTION
I've tried to sync two databases today (had always used `clone` before), and encountered two issues:

1. There seemed to be some confusion between source and target connections. The check `!dbList.includes(targetDB)` used data from source database, rather than target one. In a similar fashion, [line 257, `yield r.db(targetDB).table(table).sync().run()`](https://github.com/internalfx/thinker/blob/81bd4f0/lib/commands/sync.js#L257) looks suspicious to me. I've made a commit that gets rid of `r` completely and uses `sr`/`tr` explicitly.

2. The process had completely stuck for compound IDs, like `[1, "foo"]`. The issue was caused that neither `si.id === ti.id`, nor `si.id < ti.id`, nor `si.id > ti.id` evaluated to true, so the loop had continued forever over the same records. I've slightly modified the logic, based on what RethinkDB docs says about the ordering. While this may still (quite probably) fail for complex data structures, as I'm not sure if there's a way to ask RethinkDB to deeply annotate them with `typeOf` (and I'm not sure about how JS driver coerces objects and how to infer ReQL type from the JS value), it should work for common cases, like my `[userId, date]` PKs.

Hope those two could be useful. Submitting both in a single PR, because I'm lazy (sorry!) to cherry-pick them into distinct branches.