### PR TITLE
Sync for compound and heterogeneously-typed PKs

### DIFF
--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -8,8 +8,8 @@ let co = require('co')
 let colors = require('colors')
 let asyncEach = require('../asyncEach')
 let blockingQueue = require('../blockingQueue')
+let compareValues = require('../compareValues')
 let moment = require('moment')
-let maxId = '~~~~~~~~~~~~~~~~~~~~~~'
 
 let HELPTEXT = `
 
@@ -221,8 +221,10 @@ module.exports = function *(argv) {
       }
     })
 
-    while (si.id !== maxId || ti.id !== maxId) {
-      if (si.id === ti.id) {
+    while (si.id !== Infinity && ti.id !== Infinity) {
+      const cmp = compareValues(si.id, ti.id)
+
+      if (cmp === 0) {  // si.id === ti.id  ->  check hashes
         let sid = si.id
         let tid = ti.id
         if (si.hash !== ti.hash) {
@@ -235,7 +237,7 @@ module.exports = function *(argv) {
         si = yield getNextIdx(sourceCursor, si)
         ti = yield getNextIdx(targetCursor, ti)
         recordsProcessed += 1
-      } else if (si.id < ti.id) {
+      } else if (cmp < 0) {  // si.id < ti.id  ->  copy si
         let sid = si.id
         yield queue.push(function *() {
           let record = yield sr.db(sourceDB).table(table).get(sid).run()
@@ -244,13 +246,16 @@ module.exports = function *(argv) {
         })
         si = yield getNextIdx(sourceCursor, si)
         recordsProcessed += 1
-      } else if (si.id > ti.id) {
+      } else if (cmp > 0) {  // si.id > ti.id  ->  delete ti
         let tid = ti.id
         yield queue.push(function *() {
           yield tr.db(targetDB).table(table).get(tid).delete().run()
         })
         ti = yield getNextIdx(targetCursor, ti)
         deleted += 1
+      } else {
+        console.log(colors.red(`ERROR! Cannot sync, encountered uncomparable PKs`))
+        break
       }
     }
 
@@ -263,14 +268,14 @@ module.exports = function *(argv) {
 }
 
 var getNextIdx = function *(cursor, idx) {
-  if (idx.id !== maxId) {
+  if (idx.id !== Infinity) {
     try {
       idx = yield cursor.next()
     } catch (err) {
       if (err.message === 'No more rows in the cursor.') {
         idx = {
           hash: '',
-          id: maxId
+          id: Infinity
         }
       }
     }

--- a/lib/compareValues.js
+++ b/lib/compareValues.js
@@ -1,0 +1,105 @@
+const _ = require("lodash");
+
+function inferTypeOf(value) {
+  // Given a value from RethinkDB, tries to infer its ReQL type.
+  // Returns a string value, similar to r.typeOf result, or an empty
+  // string if the type is not recognized or unsupported.
+  switch (typeof value) {
+    case "string":
+      return "STRING";
+    case "number":
+      return "NUMBER";
+    case "boolean":
+      return "BOOL";
+    case "null":
+      return "NULL";
+    case "object":
+      // TODO: Implement check for PTYPE<GEOMETRY>
+      if (_.isArray(value)) {
+        return "ARRAY";
+      } else if (_.isDate(value)) {
+        return "PTYPE<TIME>";
+      } else if (_.isTypedArray(value)) {
+        return "PTYPE<BINARY>";
+      } else {
+        return "OBJECT";
+      }
+    default:
+      return "";
+  }
+}
+
+function spaceship(a, b) {
+  // A simple three-way comparison ("spaceship operator") function.
+  // Using JS built-in comparison logic, returns 0, -1 or 1,
+  // depending on whenever values compare equal, less or greater.
+  // Returns null if neither of comparisons succeed (non-comparable).
+  if (a === b) {
+    return 0;
+  } else if (a < b) {
+    return -1;
+  } else if (a > b) {
+    return 1;
+  } else {
+    return null;
+  }
+}
+
+function compareValues(a, b) {
+  // Compares two values in a (hopefully) same manner as RethinkDB would do.
+  // Returns 0, -1 or 1 (see `spaceship` function) or null if cannot compare.
+  //
+  // A special value of Infinity (a value that can't be stored in RethinkDB)
+  // is treated as greater than any other value. However, please note that
+  // the behavior of comparing two Infinity values is undefined.
+
+  // Fast path for strings, improving performance for the most common case.
+  if (typeof a === "string" && typeof b === "string") {
+    return a === b ? 0 : (a < b ? -1 : 1);
+  }
+
+  if (a === Infinity) { return 1; }    // Infinity > *
+  if (b === Infinity) { return -1; }   // * < Infinity
+
+  const ta = inferTypeOf(a),
+        tb = inferTypeOf(b);
+
+  if (ta === "" || tb === "") {
+    return null;
+  }
+  if (ta !== tb) {
+    return spaceship(ta, tb);
+  }
+
+  switch (ta) {
+    case "STRING":
+    case "NUMBER":
+    case "BOOL":
+    case "NULL":
+      return spaceship(a, b);
+    case "PTYPE<TIME>":
+      return spaceship(a.getTime(), b.getTime());
+    case "PTYPE<BINARY>":
+      return null; // unsupported
+    case "ARRAY":
+      for (let pair of _.zip(a, b)) {
+        if (pair[0] === undefined) {
+          return -1;
+        } else if (pair[1] === undefined) {
+          return 1;
+        } else {
+          const c = compareValues(pair[0], pair[1]);
+          if (c !== 0) {
+            return c;
+          }
+        }
+      }
+      return 0;
+    case "OBJECT":
+      return compareValues(_.toPairs(a).sort(), _.toPairs(b).sort());
+    default:
+      return null;
+  }
+}
+
+module.exports = compareValues;

--- a/lib/compareValues.js
+++ b/lib/compareValues.js
@@ -1,51 +1,51 @@
-const _ = require("lodash");
+const _ = require('lodash')
 
-function inferTypeOf(value) {
+function inferTypeOf (value) {
   // Given a value from RethinkDB, tries to infer its ReQL type.
   // Returns a string value, similar to r.typeOf result, or an empty
   // string if the type is not recognized or unsupported.
   switch (typeof value) {
-    case "string":
-      return "STRING";
-    case "number":
-      return "NUMBER";
-    case "boolean":
-      return "BOOL";
-    case "null":
-      return "NULL";
-    case "object":
+    case 'string':
+      return 'STRING'
+    case 'number':
+      return 'NUMBER'
+    case 'boolean':
+      return 'BOOL'
+    case 'null':
+      return 'NULL'
+    case 'object':
       // TODO: Implement check for PTYPE<GEOMETRY>
       if (_.isArray(value)) {
-        return "ARRAY";
+        return 'ARRAY'
       } else if (_.isDate(value)) {
-        return "PTYPE<TIME>";
+        return 'PTYPE<TIME>'
       } else if (_.isTypedArray(value)) {
-        return "PTYPE<BINARY>";
+        return 'PTYPE<BINARY>'
       } else {
-        return "OBJECT";
+        return 'OBJECT'
       }
     default:
-      return "";
+      return ''
   }
 }
 
-function spaceship(a, b) {
+function spaceship (a, b) {
   // A simple three-way comparison ("spaceship operator") function.
   // Using JS built-in comparison logic, returns 0, -1 or 1,
   // depending on whenever values compare equal, less or greater.
   // Returns null if neither of comparisons succeed (non-comparable).
   if (a === b) {
-    return 0;
+    return 0
   } else if (a < b) {
-    return -1;
+    return -1
   } else if (a > b) {
-    return 1;
+    return 1
   } else {
-    return null;
+    return null
   }
 }
 
-function compareValues(a, b) {
+function compareValues (a, b) {
   // Compares two values in a (hopefully) same manner as RethinkDB would do.
   // Returns 0, -1 or 1 (see `spaceship` function) or null if cannot compare.
   //
@@ -54,52 +54,52 @@ function compareValues(a, b) {
   // the behavior of comparing two Infinity values is undefined.
 
   // Fast path for strings, improving performance for the most common case.
-  if (typeof a === "string" && typeof b === "string") {
-    return a === b ? 0 : (a < b ? -1 : 1);
+  if (typeof a === 'string' && typeof b === 'string') {
+    return a === b ? 0 : (a < b ? -1 : 1)
   }
 
-  if (a === Infinity) { return 1; }    // Infinity > *
-  if (b === Infinity) { return -1; }   // * < Infinity
+  if (a === Infinity) { return 1 }    // Infinity > *
+  if (b === Infinity) { return -1 }   // * < Infinity
 
-  const ta = inferTypeOf(a),
-        tb = inferTypeOf(b);
+  const ta = inferTypeOf(a)
+  const tb = inferTypeOf(b)
 
-  if (ta === "" || tb === "") {
-    return null;
+  if (ta === '' || tb === '') {
+    return null
   }
   if (ta !== tb) {
-    return spaceship(ta, tb);
+    return spaceship(ta, tb)
   }
 
   switch (ta) {
-    case "STRING":
-    case "NUMBER":
-    case "BOOL":
-    case "NULL":
-      return spaceship(a, b);
-    case "PTYPE<TIME>":
-      return spaceship(a.getTime(), b.getTime());
-    case "PTYPE<BINARY>":
-      return null; // unsupported
-    case "ARRAY":
+    case 'STRING':
+    case 'NUMBER':
+    case 'BOOL':
+    case 'NULL':
+      return spaceship(a, b)
+    case 'PTYPE<TIME>':
+      return spaceship(a.getTime(), b.getTime())
+    case 'PTYPE<BINARY>':
+      return null // unsupported
+    case 'ARRAY':
       for (let pair of _.zip(a, b)) {
         if (pair[0] === undefined) {
-          return -1;
+          return -1
         } else if (pair[1] === undefined) {
-          return 1;
+          return 1
         } else {
-          const c = compareValues(pair[0], pair[1]);
+          const c = compareValues(pair[0], pair[1])
           if (c !== 0) {
-            return c;
+            return c
           }
         }
       }
-      return 0;
-    case "OBJECT":
-      return compareValues(_.toPairs(a).sort(), _.toPairs(b).sort());
+      return 0
+    case 'OBJECT':
+      return compareValues(_.toPairs(a).sort(), _.toPairs(b).sort())
     default:
-      return null;
+      return null
   }
 }
 
-module.exports = compareValues;
+module.exports = compareValues


### PR DESCRIPTION
Continuing discussion from #10 and [this gist](https://gist.github.com/drdaeman/760ade50b6cb5a58caea110ff6e650f9), this is my experimental implementation for support of the compound PK and PKs with non-string values.

- We try to deduce ReQL type, based on JS value we have, and compare values with regard to the types - in a same manner RethinkDB does it (alphabetically ordered by type name).

- If we cannot compare values (e.g. if PK contains a value of unknown or unsupported type), we fail explicitly, aborting work on the table.

- There's a fast path for strings, to minimize the performance impact for the most common case. Not sure about its inclusion in terms of readability, but I guess it's worth extra 3% speedup.

- Hardcoded string `maxId` is replaced with `Infinity`, as this value cannot be stored in RethinkDB (so we won't encounter it) and has a reasonably meaningful semantics in regards to ordering.