### PR TITLE
Fix #12: Use raw time format when fetching documents

### DIFF
--- a/lib/commands/clone.js
+++ b/lib/commands/clone.js
@@ -245,7 +245,7 @@ module.exports = function *(argv) {
     })
 
     yield asyncEach(tablesToCopyList, function *(table, idx) {
-      let cursor = yield sr.db(sourceDB).table(table).run({cursor: true})
+      let cursor = yield sr.db(sourceDB).table(table).run({cursor: true, timeFormat: 'raw'})
       let tableDone = false
 
       while (!tableDone) {

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -229,7 +229,7 @@ module.exports = function *(argv) {
         let tid = ti.id
         if (si.hash !== ti.hash) {
           yield queue.push(function *() {
-            let record = yield sr.db(sourceDB).table(table).get(sid).run()
+            let record = yield sr.db(sourceDB).table(table).get(sid).run({timeFormat: 'raw'})
             yield tr.db(targetDB).table(table).get(tid).replace(record).run()
             updated += 1
           })
@@ -240,7 +240,7 @@ module.exports = function *(argv) {
       } else if (cmp < 0) {  // si.id < ti.id  ->  copy si
         let sid = si.id
         yield queue.push(function *() {
-          let record = yield sr.db(sourceDB).table(table).get(sid).run()
+          let record = yield sr.db(sourceDB).table(table).get(sid).run({timeFormat: 'raw'})
           yield tr.db(targetDB).table(table).insert(record).run()
           created += 1
         })

--- a/lib/compareValues.js
+++ b/lib/compareValues.js
@@ -21,8 +21,6 @@ function inferTypeOf (value) {
         return 'PTYPE<TIME>'
       } else if (_.isTypedArray(value)) {
         return 'PTYPE<BINARY>'
-      } else if (value['$reql_type$'] === 'TIME') {
-        return 'PTYPE<TIME>'
       } else {
         return 'OBJECT'
       }
@@ -80,9 +78,7 @@ function compareValues (a, b) {
     case 'NULL':
       return spaceship(a, b)
     case 'PTYPE<TIME>':
-      const timeA = _.isDate(a) ? a.getTime() : a.epoch_time * 1000
-      const timeB = _.isDate(b) ? b.getTime() : b.epoch_time * 1000
-      return spaceship(timeA, timeB)
+      return spaceship(a.getTime(), b.getTime())
     case 'PTYPE<BINARY>':
       return null // unsupported
     case 'ARRAY':

--- a/lib/compareValues.js
+++ b/lib/compareValues.js
@@ -21,6 +21,8 @@ function inferTypeOf (value) {
         return 'PTYPE<TIME>'
       } else if (_.isTypedArray(value)) {
         return 'PTYPE<BINARY>'
+      } else if (value['$reql_type$'] === 'TIME') {
+        return 'PTYPE<TIME>'
       } else {
         return 'OBJECT'
       }
@@ -78,7 +80,9 @@ function compareValues (a, b) {
     case 'NULL':
       return spaceship(a, b)
     case 'PTYPE<TIME>':
-      return spaceship(a.getTime(), b.getTime())
+      const timeA = _.isDate(a) ? a.getTime() : a.epoch_time * 1000
+      const timeB = _.isDate(b) ? b.getTime() : b.epoch_time * 1000
+      return spaceship(timeA, timeB)
     case 'PTYPE<BINARY>':
       return null // unsupported
     case 'ARRAY':


### PR DESCRIPTION
This PR should resolve #12.

I've tested it locally and it seems to work for me. Without `timeFormat: 'raw'` timezone information was lost (as `Date` always converts to localtime), and with them DB copies are identical.

RethinkDB treats same timestamps in different timezones to be equal, e.g. `r.ISO8601("2017-01-01T10:00:00+00:00").eq(r.ISO8601("2017-01-01T05:00:00-05:00"))` is `true`. As it's impossible to have a duplicate, I haven't applied `timeFormat: 'raw'` to the cursors that iterate over PKs.

Actually, I've tried to [write some automated tests](https://github.com/drdaeman/thinker/commit/83b7d2d8cab976e6890d65931fa4dce24078a572) (with assumption that RethinkDB is available on `localhost:28015` - we can probably add Travis CI with `rethinkdb` addon) but I haven't included them, because the code felt really messy. I guess, I need to look how others are writing their tests - I certainly lack any experience in this area.