### PR TITLE
[APP-1369] feat: silent mode, company ids filter, comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,14 @@ Options:
 
   --tu                                Target username, overrides --user
   --tp                                Target password, overrides --password
+
+  --silent, --s                             Skip interactive approval
+
+  --c, --companyIds=<id1,id2>               Uses seconary ids to filter Company Secondary Index from what is synced
+```
+
+To copy specific tables by specific company ids you would do the following:
+
+```
+./bin/thinker sync --sh <FROM> --th <TO> --sd gather --td gather --c sa0oiol9,phbq3484 --s --pt accounts,bookings,charges,comments,contacts,locations,logins,messages,policies,rooms,templates,users
 ```

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -24,24 +24,27 @@ let HELPTEXT = `
     thinker sync -h | --help
 
   Options:
-    --sh, --sourceHost=<host[:port]>    Source host, defaults to 'localhost:21015'
-    --th, --targetHost=<host[:port]>    Target host, defaults to 'localhost:21015'
-    --sd, --sourceDB=<dbName>           Source database
-    --td, --targetDB=<dbName>           Target database
+    --sh, --sourceHost=<host[:port]>          Source host, defaults to 'localhost:21015'
+    --th, --targetHost=<host[:port]>          Target host, defaults to 'localhost:21015'
+    --sd, --sourceDB=<dbName>                 Source database
+    --td, --targetDB=<dbName>                 Target database
 
-    --pt, --pickTables=<table1,table2>  Comma separated list of tables to sync (whitelist)
-    --ot, --omitTables=<table1,table2>  Comma separated list of tables to ignore (blacklist)
-                                        Note: '--pt' and '--ot' are mutually exclusive options.
+    --pt, --pickTables=<table1,table2>        Comma separated list of tables to sync (whitelist)
+    --ot, --omitTables=<table1,table2>        Comma separated list of tables to ignore (blacklist)
+                                              Note: '--pt' and '--ot' are mutually exclusive options.
 
-    --user                              Source and Target username
-    --password                          Source and Target password
+    --user                                    Source and Target username
+    --password                                Source and Target password
 
-    --su                                Source username, overrides --user
-    --sp                                Source password, overrides --password
+    --su                                      Source username, overrides --user
+    --sp                                      Source password, overrides --password
 
-    --tu                                Target username, overrides --user
-    --tp                                Target password, overrides --password
+    --tu                                      Target username, overrides --user
+    --tp                                      Target password, overrides --password
 
+    --silent, --s                             Skip interactive approval
+
+    --c, --companyIds=<id1,id2>               Uses seconary ids to filter Company Secondary Index from what is synced
 `
 
 module.exports = function *(argv) {
@@ -60,9 +63,12 @@ module.exports = function *(argv) {
   let sourcePassword = argv.sp ? argv.sp : argv.password ? argv.password : ''
   let targetUser = argv.tu ? argv.tu : argv.user ? argv.user : 'admin'
   let targetPassword = argv.tp ? argv.tp : argv.password ? argv.password : ''
+  let companyIds = argv.c ? argv.c : argv.companyIds ? argv.companyIds : null
+  const silent = argv.s ? argv.s : argv.silent ? argv.silent : null
 
   pickTables = _.isString(pickTables) ? pickTables.split(',') : null
   omitTables = _.isString(omitTables) ? omitTables.split(',') : null
+  companyIds = _.isString(companyIds) ? companyIds.split(',') : null
 
   if (argv.h || argv.help) {
     console.log(HELPTEXT)
@@ -121,16 +127,20 @@ module.exports = function *(argv) {
 
   console.log(confMessage)
 
-  let answer = yield inquirer.prompt([{
-    type: 'confirm',
-    name: 'confirmed',
-    message: 'Proceed?',
-    default: false
-  }])
+  if (!silent) {
 
-  if (!answer.confirmed) {
-    console.log(colors.red('ABORT!'))
-    return
+    let answer = yield inquirer.prompt([{
+      type: 'confirm',
+      name: 'confirmed',
+      message: 'Proceed?',
+      default: false
+    }])
+
+    if (!answer.confirmed) {
+      console.log(colors.red('ABORT!'))
+      return
+    }
+
   }
 
   startTime = moment()
@@ -192,12 +202,36 @@ module.exports = function *(argv) {
     let queue = blockingQueue()
 
     console.log(`Synchronizing ${totalRecords} records in ${table}...                                                                        `)
-    let sourceCursor = yield sr.db(sourceDB).table(table).orderBy({index: sr.asc('id')})
-      .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
-      .run({cursor: true})
-    let targetCursor = yield tr.db(targetDB).table(table).orderBy({index: tr.asc('id')})
-      .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
-      .run({cursor: true})
+    let sourceCursor
+    let targetCursor
+    if (companyIds) {
+      console.log(`Synchronizing by Companies: ${companyIds}`)
+      sourceCursor = yield sr.db(sourceDB).table(table)
+        .orderBy({index: "id"})
+        .filter(el =>
+          sr.expr(companyIds)
+          .contains(el("Company"))
+        )
+        .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
+        .run({cursor: true})
+      targetCursor = yield tr.db(targetDB).table(table)
+        .orderBy({index: "id"})
+        .filter(el =>
+          tr.expr(companyIds)
+          .contains(el("Company"))
+        )
+        .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
+        .run({cursor: true})
+    } else {
+      console.log(`Synchronizing everything`)
+      sourceCursor = yield sr.db(sourceDB).table(table)
+        .orderBy({index: sr.asc('id')})
+        .map(function (row) { return {id: row('id'), hash: sr.uuid(row.toJSON())} })
+        .run({cursor: true})
+      targetCursor = yield tr.db(targetDB).table(table).orderBy({index: tr.asc('id')})
+        .map(function (row) { return {id: row('id'), hash: tr.uuid(row.toJSON())} })
+        .run({cursor: true})
+    }
 
     let si = {}
     let ti = {}


### PR DESCRIPTION
Adds a silent mode and a flag to only copy data from certain companies

New flags

  - **c** or **companyIds** Comma separated list of company ids
  - **s** or **silent** Run without waiting for user input (might be renamed to autoApprove)

Usage examples

```
thinker sync --sh 127.0.0.1:28025 --th 127.0.0.1:28015 --sd gather --td gather --c sa0oiol9,phbq3484 --s --pt accounts,bookings,charges,comments,contacts,locations,logins,messages,policies,rooms,templates,users
```

or all tables

```
sync --sh 127.0.0.1:28025 --th 127.0.0.1:28015 --sd gather --td gather --c sa0oiol9,phbq3484 --s
```